### PR TITLE
org.apache.dubbo.config.ApplicationConfig#0

### DIFF
--- a/src/main/java/com/alibaba/spring/beans/factory/annotation/ConfigurationBeanBindingRegistrar.java
+++ b/src/main/java/com/alibaba/spring/beans/factory/annotation/ConfigurationBeanBindingRegistrar.java
@@ -111,7 +111,7 @@ public class ConfigurationBeanBindingRegistrar implements ImportBeanDefinitionRe
                 singleton(resolveSingleBeanName(configurationProperties, configClass, registry));
 
         for (String beanName : beanNames) {
-            registerConfigurationBean(beanName, configClass, multiple, ignoreUnknownFields, ignoreInvalidFields,
+            registerConfigurationBean(beanName.replace("#", "_"), configClass, multiple, ignoreUnknownFields, ignoreInvalidFields,
                     configurationProperties, registry);
         }
 


### PR DESCRIPTION
Invalid name="org.apache.dubbo.config.ApplicationConfig#0" contains illegal character, only digit, letter, '-', '_' or '.' is legal.