### PR TITLE
Fix the interfaceClass conversion error in dubbo fetch attributes

### DIFF
--- a/src/main/java/com/alibaba/spring/beans/factory/annotation/AbstractAnnotationBeanPostProcessor.java
+++ b/src/main/java/com/alibaba/spring/beans/factory/annotation/AbstractAnnotationBeanPostProcessor.java
@@ -623,6 +623,10 @@ public abstract class AbstractAnnotationBeanPostProcessor extends
 
             Class<?> injectedType = resolveInjectedType(bean, field);
 
+            if (attributes.get("interfaceClass") != null) {
+                this.attributes.put("interfaceClass", injectedType);
+            }
+
             Object injectedObject = getInjectedObject(attributes, bean, beanName, injectedType, this);
 
             ReflectionUtils.makeAccessible(field);


### PR DESCRIPTION
spring-context-support interfaceClass is a string type, but Dubbo requires a Class type, In AbstractAnnotationBeanPostProcessor did not update the interfaceClass type, can cause the ClassCaseException